### PR TITLE
Update recipe: tblis-v1.2.0 more Tier-1 platforms

### DIFF
--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -14,17 +14,66 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd tblis/
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+
+for i in ./Makefile.* ./configure*; do
+
+    # Building in container forbids -march options
+    sed -i "s/-march[^ ]*//g" $i
+
+done
+
+case ${target} in
+    # Unlike stated in Wiki, 
+    # TBLIS automatically detects threading model.
+    *"x86_64"*"linux"*) 
+        export BLI_CONFIG=x86
+        export BLI_THREAD=openmp
+        ;;
+    *"x86_64"*"w64"*)
+        # Windows lacks support for some instructions.
+        # Building only for AMD processors.
+        export BLI_CONFIG=amd
+        export BLI_THREAD=openmp
+        ;;
+    *"x86_64"*"apple"*) 
+        export BLI_CONFIG=x86
+        export BLI_THREAD=openmp
+        export CC=gcc
+        export CXX=g++
+        ;;
+    *"x86_64"*"freebsd"*) 
+        export BLI_CONFIG=x86
+        export BLI_THREAD=openmp
+        export CC=gcc
+        export CXX=g++
+        ;;
+    *)
+        ;; 
+
+esac
+
+CFG_OPTION_POSIX="--prefix=${prefix} --build=${MACHTYPE} --host=${target}"
+# ./configure will warn about --enable-thread-model but it is actually effective.
+CFG_OPTION_TBLIS="--enable-config=${BLI_CONFIG} --enable-thread-model=${BLI_THREAD}"
+
+./configure ${CFG_OPTION_TBLIS} ${CFG_OPTION_POSIX}
 make -j${nproc}
-cp lib/.libs/libtblis.so.0.0.0 ${libdir}/libtblis.so.0
-cp src/external/tci/lib/.libs/libtci.so.0.0.0 ${libdir}/libtci.so.0
+make install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
     Linux(:x86_64, libc=:glibc),
-    Linux(:x86_64, libc=:musl)
+    # Some StdCpp headers missing for linux-musl toolchain.
+    # Linux(:x86_64, libc=:musl),
+    MacOS(:x86_64),
+    FreeBSD(:x86_64)
+    # Due to the following reasons, MinGW build is commented out:
+    # - Lack of support of some Intel XMM instructions;
+    # - Lack of posix_memalign (solvable as _aligned_malloc is available);
+    # - This build system fails to produce .dll on MinGW;
+    # Windows(:x86_64),
 ]
 platforms = expand_cxxstring_abis(platforms)
 


### PR DESCRIPTION
Previous script seems not compiling on containers provided by current master.
Container build does not allow specifying -march options.

This update:
- Patches scripts before compiling to remove incompatible options;
- Adds support for macOS and FreeBSD;

Limitations:
- **[Looking for help]** Support for MUSL Linux is dropped due to seemingly lack of standard library files; (`<complex>` not found);
- **[Working on upstream]** Windows is not supported yet due to the current autotool's not giving dynamic libraries under MinGW.